### PR TITLE
Add ability to include/change backend headers in event

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install pyotrs
 
     - name: Run the testsuite
       run: test/test.py

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,19 @@
+# Wartungsplan development documentation
+
+## Run the test suite
+
+   source venv/bin/activate
+   # install optional dependencies
+   pip install pyotrs
+
+## Pypi release
+
+   cd /tmp
+   python3 -m venv venv
+   source venv/bin/activate
+   git clone git@github.com:science-computing/wartungsplan
+   cd wartungsplan
+   pip install -r dev-requirements.txt
+   python3 -m build --sdist .
+   python3 -m build --wheel .
+   twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ action per event like sending an email or opening a ticket.
     python3 -m venv venv
     # enter the venv
     source venv/bin/activate
-    # install dependecies
-    pip install -r requirements.txt
     # install Wartungsplan
-    pip install .
-    # run the test suite
-    test/test.py
+    pip install wartungsplan
 
 
 ## Events from icalendar ##

--- a/README.md
+++ b/README.md
@@ -36,6 +36,42 @@ The config file:
     #Directory to ics file. Calendar only needs to be readable.
     directory = /media/shareX/Wartungspläne.ics
 
+### Mode of operation ###
+
+You would create several calendar files according to your need and run them
+regularly using cron or systemd.
+
+The calendars are split first of all by backend then by partition (the group
+of people you want to give access).
+
+ - E-Mail notification
+ - Ticketing system
+
+Then for example four calendars for four responsibilities (teams):
+
+ - Client machine tasks
+ - Server related tasks
+ - Network
+ - Public facing servers
+ - Internal servers
+ - Database servers
+
+Another aproach could be to separate by duration (to run Wartungsplan daily,
+weekly, monthly):
+
+ - Tasks to finish the same day
+ - That week
+ - That month
+
+If you already have different queues set up in your ticketing system you can
+also start from there.
+
+Be careful to not have more calendars than events ;-) 60 events per calender is
+not too much, having to include 12 calenders in Outlook is a disaster, always.
+
+The calendar files are on the local file system, a network share or otherwise
+synchronized/transported.
+
 ### Microsoft Outlook ###
 
 It is strongly recommended to explicitly sync the calendar back to its source:
@@ -99,3 +135,11 @@ The config file:
       --end-date END_DATE, -e END_DATE
                             End Date e.g. 2023-05-03. Default is start-date + 1
                             day. (00:00:00 respectively)
+
+## Contact ##
+
+In case you want or need to contact us in private because you don't want the
+entire world to know, security related issues ... or to just say "Hello":
+
+felix.bauer@eviden.com
+christian.habrom@eviden.com

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,6 @@
-pylint
+pylint==2.17.5
+build==0.10.0
+twine==4.0.2
+
+# optional dependencies
+pyotrs==1.0.1

--- a/plan.conf.sample
+++ b/plan.conf.sample
@@ -11,11 +11,26 @@ recipient = michael_jackson@example.com
 
 [otrs]
 server = http://localhost
-#webservicename = GenericTicketConnectorREST
 username = restapiuser
 password = AiX3sheeIyahf8aaQuah2wio
+customUser = root@localhost
 tickettitel = Titel
 queue = Queueebene1::Queueebene2
 state = New
 priority = 1 very low
 footer = Ticket automatically created by Wartungsplan
+
+[headers]
+# Configure here the available (allowed) headers with their
+# default value (if present but empty in calendar event)
+#
+# For mail
+X-Priority = 3
+X-TicketID =
+To = example@example.com
+#
+# For OTRS
+tickettitel = Titel
+queue = Queueebene1::Queueebene2
+state = New
+priority = 1 very low


### PR DESCRIPTION
Before it was not possible to change the header within the email backend.

For example: 
Customized headers can be used to provide more information to the system receiving the email message.


Now a configuration allows headers that can be set/overwritten by the event body.

This includes an architectural change:
We define a new base class 'Backend' that every backend needs to implement.
It specifies how sub classes have to be structured and the steps every backend performs.